### PR TITLE
- Bug fix for opponent team in period sum data

### DIFF
--- a/EH_scrape_functions.R
+++ b/EH_scrape_functions.R
@@ -1755,7 +1755,7 @@ sc.shifts_parse <- function(game_id_fun, season_id_fun, shifts_list, roster_data
       season =    game_info_data$season, 
       session =   game_info_data$session,
       Team =      event_team, 
-      Opponent =  ifelse(Team == game_info_data$home_team, game_info_data$home_team, game_info_data$away_team), 
+      Opponent =  ifelse(Team == game_info_data$home_team, game_info_data$away_team, game_info_data$home_team),
       is_home =   1 * (Team == game_info_data$home_team)
       ) %>% 
     left_join(


### PR DESCRIPTION
I noticed that the opponent value in player_periods was just duplicating the home team string.